### PR TITLE
Setting timings for tandy_16_gfx mode

### DIFF
--- a/verilog/cga.v
+++ b/verilog/cga.v
@@ -315,7 +315,8 @@ module cga(
         .disp_pipeline(disp_pipeline),
         .isa_op_enable(isa_op_enable),
         .hclk(hclk),
-        .lclk(lclk)
+        .lclk(lclk),
+        .tandy_16_gfx(tandy_16_mode & grph_mode & hres_mode)
     );
 
     // Pixel pusher

--- a/verilog/cga_sequencer.v
+++ b/verilog/cga_sequencer.v
@@ -20,7 +20,8 @@ module cga_sequencer(
     output disp_pipeline,
     output isa_op_enable,
     output hclk,
-    output lclk
+    output lclk,
+    input tandy_16_gfx
     );
 
     wire crtc_clk_int;
@@ -50,7 +51,7 @@ module cga_sequencer(
     assign vram_read_char = (clkdiv == 5'd2) || (hres_mode ? (clkdiv == 5'd18) : 0);
     assign vram_read_att = (clkdiv == 5'd3) || (hres_mode ? (clkdiv == 5'd19) : 0);
     assign charrom_read = (clkdiv == 5'd3) || (hres_mode ? (clkdiv == 5'd19) : 0);// 3 and 19?
-    assign disp_pipeline = (clkdiv == 5'd4) || (hres_mode ? (clkdiv == 5'd20) : 0);
+    assign disp_pipeline = (clkdiv == (tandy_16_gfx ? 5'd7 : 5'd4)) || (hres_mode ? (clkdiv == (tandy_16_gfx ? 5'd23 : 5'd20)) : 0);
     assign crtc_clk = crtc_clk_int;
     assign clk_seq = clkdiv;
     // Leave a gap of at least 2 cycles between the end of ISA operation and


### PR DESCRIPTION
I propose this improvement to solve a ghost line issue en Tandy 320x200x16, with the loss of the last line. It was a timing issue, specifically those generated by the disp_pipeline signal.